### PR TITLE
Adopt community contribution to alway run as nonRoot 

### DIFF
--- a/templates/server-deployment.yaml
+++ b/templates/server-deployment.yaml
@@ -45,12 +45,12 @@ spec:
         {{- end }}
     spec:
       {{ include "temporal.serviceAccount" $ }}
-      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       {{- if semverCompare ">=1.13.0" $.Chart.AppVersion}}
       securityContext:
         fsGroup: 1000 #temporal group
         runAsUser: 1000 #temporal user
       {{- end }}
+      {{- if or $.Values.cassandra.enabled (or $.Values.elasticsearch.enabled $.Values.elasticsearch.external)}}
       initContainers:
         {{- if $.Values.cassandra.enabled }}
         - name: check-cassandra-service


### PR DESCRIPTION
Temporal should run as nonroot for security best practices. Right now it's only configured to do so when Cassandra or Elasticsearch is enabled.

Original PR: https://github.com/temporalio/helm-charts/pull/308